### PR TITLE
chore: To use library ckb-sdk 2.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.2", features = ["derive"] }
 
-ckb-crypto = { version = "=0.104.0", features = ["secp"] }
-ckb-hash = "=0.104.0"
-ckb-jsonrpc-types = "=0.104.0"
-# ckb-sdk = "1.0.1"
-ckb-sdk = { git = "https://github.com/nervosnetwork/ckb-sdk-rust.git", branch = "master" }
-ckb-signer = "0.2.0"
-ckb-types = "=0.104.0"
+ckb-crypto = { version = "=0.105.1", features = ["secp"] }
+ckb-hash = "=0.105.1"
+ckb-jsonrpc-types = "=0.105.1"
+ckb-sdk = "2.3.0"
+#ckb-sdk = { git = "https://github.com/nervosnetwork/ckb-sdk-rust.git", branch = "master" }
+ckb-signer = "0.3.0"
+ckb-types = "0.105.1"
 
 dirs = "1.0.5"
 anyhow = "1.0"
@@ -29,4 +29,4 @@ yaml-rust = "0.4.3"
 
 jsonrpc-core = "18"
 
-secp256k1 = { version = "0.20", features = ["recovery"] }
+secp256k1 = { version = "0.24", features = ["recovery"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,34 @@
-# Configuration
+# omnilock-cli
+CKB omnilock command line tool.
+
+This tool can do omnilock related operations, like create a CKB omnilock address, transfer capacity from omnilock address to any address.
+
+[ckb-cli](https://github.com/nervosnetwork/ckb-cli) should be used to view transaction, get capacity from an address, view block information etc.
+
+Now the tool can only build address for pubkey-hash/multisig/ethereum, and transfer from these type of addresses.
+
+To be supported features:
+- Owner lock auth content;
+- Administrator mode;
+- anyone-can-pay mode;
+- time-lock mode;
+- supply mode;
+
+## Features
+```
+    config           configuration related operations
+    build-address    build omni lock address
+    generate-tx      generate a transaction not signed yet, with omnilock locked cell(s) as input
+    sign             Sign the transaction
+    send             Send the transaction
+```
+
+## Configuration
 The configuration file points out which cell the omnilock script was deployed, the url of the ckb rpc and the ckb index url.
 
 The default configuration file is ~/.omnilock.yaml, it can be specified with --config parameter.
 
-## Create an empty configure file.
+### Create an empty configure file.
 - To init an empty configure file:
 ```bash
 omnilock-cli config init
@@ -14,11 +39,11 @@ If the file already exist, you should remove it or rename it first.
 omnilock-cli -c omnilock.yaml config init
 ```
 
-## Fill the configure file with correct content
+### Fill the configure file with correct content
 
 After create the empty file, modify the file, fill the correct content, so you can use the configure file in the following operation.
 
-## Check the configure file
+### Check the configure file
 - Check the default configuration file
 ```bash
 omnilock-cli config check
@@ -28,8 +53,8 @@ omnilock-cli config check
  omnilock-cli -c ~/.omnilock.yaml config check
 ```
 
-# Build omnilock address
-## Build a pubkey-hash address with receiver
+## Build omnilock address
+### Build a pubkey-hash address with receiver
 ```bash
 # build with receiver's sighash address
 omnilock-cli build-address pubkey-hash --sighash-address ckt1qyqt8xpk328d89zgl928nsgh3lelch33vvvq5u3024
@@ -46,7 +71,7 @@ The output:
 }
 ```
 
-## Build a multisig address
+### Build a multisig address
 ```bash
 omnilock-cli build-address multisig --require-first-n 0 --threshold 2 \
                                     --sighash-address ckt1qyqt8xpk328d89zgl928nsgh3lelch33vvvq5u3024 \
@@ -62,7 +87,7 @@ The output:
   "testnet": "ckt1qqklkz85v4xt39ws5dd2hdv8xsy4jnpe3envjzvddqecxr0mgvrksqgxt47sz28w4fhev44z9x6z4twsk9ma8pltqqx6nqmf"
 }
 ```
-## Build an ethereum address
+### Build an ethereum address
 1. Build with receiver's private key:
 ```bash
 omnilock-cli build-address ethereum --ethereum-privkey 0x63d86723e08f0f813a36ce6aa123bb2289d90680ae1e99d4de8cdb334553f24d
@@ -89,9 +114,9 @@ omnilock-cli build-address ethereum --ethereum-pubkey 038d3cfceea4f9c2e76c5c4f5e
 omnilock-cli build-address ethereum --ethereum-pubkey 048d3cfceea4f9c2e76c5c4f5e99aec74c26d6ac894648b5700a0b71f91f9b5c2a26b16aac1d5753e56849ea83bf795eb8b06f0b6f4e5ed7b8caca720595458039
 ```
 
-# Simple transfer
+## Simple transfer capacity from an omnilock cell
 This kind of transaction is suitable of unlock value of the cell.
-## Simple transfer from pubkey hash omnilock cell.
+### Simple transfer from pubkey hash omnilock cell.
 1. Build the address.
 ```bash
 omnilock-cli build-address pubkey-hash --sighash-address ckt1qyqt8xpk328d89zgl928nsgh3lelch33vvvq5u3024
@@ -129,7 +154,7 @@ omnilock-cli send --tx-file tx.json
 # >>> tx ac2cce746764cf9ecad7eefb82d24f8bcf5eb4708c65dde562bf96c86bbad831 sent! <<<
 ```
 
-## Simple transfer from multisig omnilock cell.
+### Simple transfer from multisig omnilock cell.
 1. Build the address.
 ```bash
 omnilock-cli build-address multisig --require-first-n 0 --threshold 2 \
@@ -185,7 +210,7 @@ omnilock-cli send --tx-file tx.json
 # >>> tx 1a4e1f8bfa22abf5f1851f894a0873f5553d3396a3794caa015b5c276345f630 sent! <<<
 ```
 
-## Simple transfer from ethereum omnilock cell.
+### Simple transfer from ethereum omnilock cell.
 1. build the address.
 ```bash
 omnilock-cli build-address ethereum --ethereum-privkey 0x63d86723e08f0f813a36ce6aa123bb2289d90680ae1e99d4de8cdb334553f24d
@@ -234,9 +259,9 @@ omnilock-cli send --tx-file tx.json
 ```
 
 
-# Manual transfer(todo)
-## Init empty transaction
-## Add input
-## Add output
-## Sign transaction
-## Send transaction
+## Manual transfer(todo)
+### Init empty transaction
+### Add input
+### Add output
+### Sign transaction
+### Send transaction

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # omnilock-cli
 CKB omnilock command line tool.
 
+For more information about omnilock, please visit the [RFC 42](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md)
+
 This tool can do omnilock related operations, like create a CKB omnilock address, transfer capacity from omnilock address to any address.
 
 [ckb-cli](https://github.com/nervosnetwork/ckb-cli) should be used to view transaction, get capacity from an address, view block information etc.

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -1,3 +1,4 @@
+use crate::util::strip_prefix_0x;
 use anyhow::Result;
 use ckb_sdk::util::zeroize_privkey;
 use ckb_types::{H160, H256};
@@ -11,12 +12,7 @@ macro_rules! arg_parser {
     ($name:ident) => {
         impl ArgParser<$name> for $name {
             fn parse(s: &str) -> Result<$name> {
-                let s = if s.starts_with("0x") || s.starts_with("0X") {
-                    &s[2..]
-                } else {
-                    s
-                };
-                Ok($name::from_str(s)?)
+                Ok($name::from_str(strip_prefix_0x(s))?)
             }
         }
     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,7 +27,7 @@ pub fn build_omnilock_cell_dep_from_client(
         .with_context(|| "while try to load live cells".to_string())?;
     ensure!(
         cell_status.cell.is_some(),
-        "Can't file the specified omnilock script cell: tx_hash {}, index {}",
+        "Can't find the specified omnilock script cell: tx_hash {}, index {}",
         tx_hash,
         index
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,9 +39,6 @@ pub struct ConfigContext {
 
     /// CKB rpc url
     pub ckb_rpc: String,
-
-    /// CKB indexer rpc url
-    pub ckb_indexer: String,
 }
 
 macro_rules! try_str {
@@ -79,17 +76,11 @@ fn expand_home_dir(path: &str) -> PathBuf {
 }
 
 impl ConfigContext {
-    pub fn new(
-        omnilock_tx_hash: H256,
-        omnilock_index: u32,
-        ckb_rpc: String,
-        ckb_indexer: String,
-    ) -> Self {
+    pub fn new(omnilock_tx_hash: H256, omnilock_index: u32, ckb_rpc: String) -> Self {
         ConfigContext {
             omnilock_tx_hash,
             omnilock_index,
             ckb_rpc,
-            ckb_indexer,
         }
     }
 
@@ -112,12 +103,10 @@ impl ConfigContext {
         let omnilock_index = try_i64!("omnilock_index", doc);
         let omnilock_index = u32::try_from(omnilock_index)?;
         let ckb_rpc = try_str!("ckb_rpc", doc);
-        let ckb_indexer = try_str!("ckb_indexer", doc);
         Ok(Self::new(
             omnilock_tx_hash,
             omnilock_index,
             ckb_rpc.to_string(),
-            ckb_indexer.to_string(),
         ))
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use ckb_types::H256;
 use clap::Subcommand;
 use yaml_rust::YamlLoader;
 
-use crate::client::build_omnilock_cell_dep;
+use crate::{client::build_omnilock_cell_dep, util::strip_prefix_0x};
 
 #[derive(Subcommand)]
 pub(crate) enum ConfigCmds {
@@ -106,6 +106,7 @@ impl ConfigContext {
         ensure!(!docs.is_empty(), "Can't parse data from {}", path);
         let doc = &docs[0];
         let omnilock_tx_hash = try_str!("omnilock_tx_hash", doc);
+        let omnilock_tx_hash = strip_prefix_0x(omnilock_tx_hash);
         let omnilock_tx_hash =
             H256::from_str(omnilock_tx_hash).with_context(|| "Fail to parse omnilock_tx_hash")?;
         let omnilock_index = try_i64!("omnilock_index", doc);

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -5,5 +5,3 @@ omnilock_tx_hash: "0000000000000000000000000000000000000000000000000000000000000
 omnilock_index: 0
 # The ckb_rpc url
 ckb_rpc: "http://127.0.0.1:8114"
-# The ckb_index url
-ckb_indexer: "http://127.0.0.1:8116"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -150,8 +150,7 @@ fn build_transfer_tx_(
     let mut cell_dep_resolver = DefaultCellDepResolver::from_genesis(&genesis_block)?;
     cell_dep_resolver.insert(cell.script_id, cell.cell_dep, "Omni Lock".to_string());
     let header_dep_resolver = DefaultHeaderDepResolver::new(env.ckb_rpc.as_str());
-    let mut cell_collector =
-        DefaultCellCollector::new(env.ckb_indexer.as_str(), env.ckb_rpc.as_str());
+    let mut cell_collector = DefaultCellCollector::new(env.ckb_rpc.as_str());
     let tx_dep_provider = DefaultTransactionDependencyProvider::new(env.ckb_rpc.as_str(), 10);
 
     // Build base transaction

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,36 +15,12 @@ use std::{fs, path::PathBuf};
 use anyhow::{Context, Result};
 use build_addr::BuildAddress;
 use ckb_sdk::CkbRpcClient;
-use ckb_types::H256;
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use config::{handle_config_cmds, ConfigCmds, ConfigContext};
 use generate::{generate_transfer_tx, GenerateTx};
 use sign::{sign_tx, SignCmd};
 
 use crate::{build_addr::build_omnilock_addr, txinfo::TxInfo};
-
-#[derive(Args)]
-struct EnvArgs {
-    /// omnilock script deploy transaction hash
-    #[clap(long, value_name = "H256")]
-    omnilock_tx_hash: H256,
-
-    /// cell index of omnilock script deploy transaction's outputs
-    #[clap(long, value_name = "NUMBER")]
-    omnilock_index: usize,
-
-    /// CKB rpc url
-    #[clap(long, value_name = "URL", default_value = "http://127.0.0.1:8114")]
-    ckb_rpc: String,
-
-    /// CKB indexer rpc url
-    #[clap(long, value_name = "URL", default_value = "http://127.0.0.1:8116")]
-    ckb_indexer: String,
-
-    /// omnilock config file path
-    #[clap(long, value_name = "FILE", default_value = "~")]
-    env_config_file: String,
-}
 
 #[derive(Subcommand)]
 enum Commands {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod keystore;
 mod sign;
 mod signer;
 mod txinfo;
+mod util;
 
 use ckb_jsonrpc_types as json_types;
 use std::{fs, path::PathBuf};

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,7 @@
+pub fn strip_prefix_0x(s: &str) -> &str {
+    if s.starts_with("0x") || s.starts_with("0X") {
+        &s[2..]
+    } else {
+        s
+    }
+}


### PR DESCRIPTION
### Features:
1. Update ckb libraries to 0.105.1, update ckb-sdk to 2.3.0
2. Remove ckb-indexer parameter
3. Can read config with hex string with 0x prefix